### PR TITLE
fix: copy .yarnrc.yml alongside package.json + yarn.lock

### DIFF
--- a/blog/Dockerfile
+++ b/blog/Dockerfile
@@ -53,7 +53,7 @@ ARG GAPI
 WORKDIR /app/realtor
 
 # Copy package.json and yarn.lock to leverage Docker cache
-COPY realtor/package.json realtor/yarn.lock ./
+COPY realtor/package.json realtor/yarn.lock realtor/.yarnrc.yml ./
 
 # Install dependencies using yarn
 RUN yarn install --immutable


### PR DESCRIPTION
## What

Add `realtor/.yarnrc.yml` to the blog Dockerfile's early `COPY` so it lands **before** `yarn install --immutable` runs. One-line change.

```diff
-COPY realtor/package.json realtor/yarn.lock ./
+COPY realtor/package.json realtor/yarn.lock realtor/.yarnrc.yml ./
```

## Why

The Yarn 4 migration in #489 introduced `realtor/.yarnrc.yml` with `nodeLinker: node-modules`. The Dockerfile's `COPY realtor/ ./` step (which would pick it up) runs **after** `yarn install`. So during install, `.yarnrc.yml` isn't present and yarn 4 uses its default `nodeLinker: pnp` instead — explicitly noted in the build log:

```
➤ YN0000: │ ESM support for PnP uses the experimental loader API and is therefore experimental
```

The later `COPY realtor/ ./` overlays the real `.yarnrc.yml`, and `yarn test` then runs expecting `node_modules` but finds PnP artefacts. It exits in ~0.3s with code 1 (way too fast for vitest to even spin up).

Reproduced locally with `docker build --no-cache --target react-builder` from `origin/develop` — same 0.3s exit-1 failure as [run 26557096898](https://github.com/etzelm/blog-in-golang/actions/runs/26557096898/job/78231145935).

## Validation

`docker build --no-cache --target react-builder` after this patch:
- yarn install in node-modules mode, clean
- yarn test --coverage --reporter=verbose --silent — full coverage table, all green
- yarn build — vite 8.0.14, 443 kB / 137 kB gzip JS

## Aside

The redirect `> test-results.txt 2>&1` on the test RUN swallows the actual error and was what made this take longer than necessary to diagnose. A follow-up PR could add `|| (cat test-results.txt; exit 1)` to surface the contents on failure, but I didn't bundle it here to keep the fix minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
