### PR TITLE
ci: bump GH Actions to Node 24 (checkout v6, changed-files v47)

### DIFF
--- a/.github/workflows/studio-workflow.yml
+++ b/.github/workflows/studio-workflow.yml
@@ -21,7 +21,7 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Build
         shell: bash
         run: |
@@ -110,10 +110,10 @@ jobs:
       build_changed: ${{ steps.changed-build-files.outputs.any_changed }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Get Changed Build Files
         id: changed-build-files
-        uses: tj-actions/changed-files@v45
+        uses: tj-actions/changed-files@v47
         with:
           files: |
             blog/go.mod
@@ -175,10 +175,10 @@ jobs:
       STUDIO_ADDR: ${{ secrets.STUDIO_ADDR }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Get Changed Article Files
         id: changed-daemon-files
-        uses: tj-actions/changed-files@v45
+        uses: tj-actions/changed-files@v47
         with:
           files: |
             daemon/articles/**


### PR DESCRIPTION
## What

Bump the two third-party actions used in `studio-workflow.yml` to their first Node 24-native major:

- **`actions/checkout` v4 → v6** — v5.0.0 was the Node 24 bump (Aug 2025); v6 is current latest. Runner floor is `v2.327.1`; Studio is on `2.334.0`. 3 call sites (`studio-build`, `build-push`, `deploy`).
- **`tj-actions/changed-files` v45 → v47** — v47.0.0 was the Node 24 bump (Sep 13 2025). 2 call sites (`build-push` for changed-build-files, `deploy` for changed-daemon-files).

## Why

Every recent run on this workflow was logging:

> ⚠️ Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: `actions/checkout@v4`, `tj-actions/changed-files@v45`. Actions will be forced to run with Node.js 24 by default starting **June 2nd, 2026**. Node.js 20 will be removed from the runner on **September 16th, 2026**.

Bumping now beats the forced default and the hard removal. Both new majors carry only the runtime swap relative to the previous version — no behavior change in our usage.

## Diff

```diff
- uses: actions/checkout@v4                # x3
+ uses: actions/checkout@v6
- uses: tj-actions/changed-files@v45       # x2
+ uses: tj-actions/changed-files@v47
```

## Validation

- yamllint passes (CI-equivalent).
- 5 line changes, single-file diff.

## Sources

- [actions/checkout v5.0.0 release](https://github.com/actions/checkout/releases/tag/v5.0.0)
- [actions/checkout releases (v6 latest)](https://github.com/actions/checkout/releases)
- [tj-actions/changed-files v47 release notes](https://github.com/tj-actions/changed-files/releases)
- [GitHub Changelog: Node 20 deprecation](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
