### PR TITLE
auth: set Secure + HttpOnly on user / userToken cookies (CodeQL #27-30)

### DIFF
--- a/blog/src/handlers/auth.handlers.go
+++ b/blog/src/handlers/auth.handlers.go
@@ -142,8 +142,11 @@ func AuthResponse(c *gin.Context) {
 
 	if CheckPasswordHash(form.Password, authForm.Password) {
 		cipher, _ := HashPassword(form.Email)
-		c.SetCookie("user", form.Email, 60*60*24, "/", "mitchelletzel.com", false, false)
-		c.SetCookie("userToken", cipher, 60*60*24, "/", "mitchelletzel.com", false, false)
+		// Secure: HTTPS-only (prod and Traefik-fronted dev are both HTTPS).
+		// HttpOnly: blocks JS access; /secure reads these server-side via
+		// c.Cookie(), unaffected. Fixes CodeQL alerts #27-30.
+		c.SetCookie("user", form.Email, 60*60*24, "/", "mitchelletzel.com", true, true)
+		c.SetCookie("userToken", cipher, 60*60*24, "/", "mitchelletzel.com", true, true)
 	} else {
 		c.HTML(
 			// Set the HTTP status to 400 (Bad Request)


### PR DESCRIPTION
## What

Two-line change in `blog/src/handlers/auth.handlers.go`: set both `Secure` and `HttpOnly` to `true` on the `user` and `userToken` cookies emitted from successful form-login.

```diff
- c.SetCookie("user",      form.Email, 60*60*24, "/", "mitchelletzel.com", false, false)
- c.SetCookie("userToken", cipher,     60*60*24, "/", "mitchelletzel.com", false, false)
+ c.SetCookie("user",      form.Email, 60*60*24, "/", "mitchelletzel.com", true,  true)
+ c.SetCookie("userToken", cipher,     60*60*24, "/", "mitchelletzel.com", true,  true)
```

## Closes

- CodeQL **#27** — Cookie 'Secure' attribute not set to true (line 145)
- CodeQL **#28** — Cookie 'Secure' attribute not set to true (line 146)
- CodeQL **#29** — Cookie 'HttpOnly' attribute not set to true (line 145)
- CodeQL **#30** — Cookie 'HttpOnly' attribute not set to true (line 146)

## Safe to flip — verified before touching

- **`HttpOnly: true`** only blocks JS (`document.cookie`) reads. The `/secure` handler reads these cookies **server-side** via `c.Cookie(...)` (`auth.handlers.go:39-40`), which is unaffected. Grepping `blog/templates/` + `blog/public/js/` shows no `document.cookie` reads of these names anywhere — no client-side breakage.
- **`Secure: true`** confines the cookies to HTTPS. Prod (`mitchelletzel.com`) and Traefik-fronted dev (`blog-dev.traefik.mitchelletzel.com`) are both HTTPS; the direct LAN HTTP debugging surface on `192.168.1.151:85` is not a login path.
- **Tests unaffected** — `auth.handlers_test.go` constructs requests with `req.AddCookie(...)` for inbound assertions; nothing asserts on `SetCookie` flags. `go test ./src/handlers/...` passes locally (4.2s, full package).

## Validation

- `go vet ./src/handlers/`: clean
- `go test ./src/handlers/...`: PASS
- 5-line diff, no other changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
