### PR TITLE
build: move AWS creds to BuildKit secrets (fixes SecretsUsedInArgOrEnv)

### DIFF
--- a/.github/workflows/studio-workflow.yml
+++ b/.github/workflows/studio-workflow.yml
@@ -141,8 +141,8 @@ jobs:
             echo "Build attempt $i..."
             if docker build \
                 --build-arg GAPI="$GAPI" \
-                --build-arg AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
-                --build-arg AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
+                --secret id=aws_access_key_id,env=AWS_ACCESS_KEY_ID \
+                --secret id=aws_secret_access_key,env=AWS_SECRET_ACCESS_KEY \
                 -t "$IMAGE" -f blog/Dockerfile .; then
               BUILD_OK=true
               break

--- a/blog/Dockerfile
+++ b/blog/Dockerfile
@@ -19,13 +19,16 @@ RUN go mod download
 # Copy the rest of the Go source code
 COPY blog/ .
 
-# Test the Go application
-# Declare ARGs for AWS creds
-ARG AWS_ACCESS_KEY_ID
-ARG AWS_SECRET_ACCESS_KEY
-# Set environment variables and run tests in the same RUN command
-RUN export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID && \
-    export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY && \
+# Test the Go application. The tests hit DynamoDB, so they need AWS creds —
+# but those creds must not persist in the image's layer history. Mount them as
+# BuildKit secrets (only visible during this single RUN, never written into a
+# layer). Replaces the prior ARG/ENV approach, which fired the docker buildx
+# `SecretsUsedInArgOrEnv` warnings on every CI build.
+# CLI side (studio-workflow.yml):
+#   --secret id=aws_access_key_id,env=AWS_ACCESS_KEY_ID
+#   --secret id=aws_secret_access_key,env=AWS_SECRET_ACCESS_KEY
+RUN --mount=type=secret,id=aws_access_key_id,env=AWS_ACCESS_KEY_ID,required=true \
+    --mount=type=secret,id=aws_secret_access_key,env=AWS_SECRET_ACCESS_KEY,required=true \
     go test -v -coverprofile=coverage.out ./...
 RUN go tool cover -func=coverage.out
 


### PR DESCRIPTION
## What

Move AWS creds (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`) out of `ARG`/`ENV` and into **BuildKit secret mounts**. Two files, +12 / −9.

```diff
- ARG AWS_ACCESS_KEY_ID
- ARG AWS_SECRET_ACCESS_KEY
- RUN export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID && \
-     export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY && \
+ RUN --mount=type=secret,id=aws_access_key_id,env=AWS_ACCESS_KEY_ID,required=true \
+     --mount=type=secret,id=aws_secret_access_key,env=AWS_SECRET_ACCESS_KEY,required=true \
      go test -v -coverprofile=coverage.out ./...
```

```diff
  docker build \
      --build-arg GAPI="$GAPI" \
-     --build-arg AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
-     --build-arg AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
+     --secret id=aws_access_key_id,env=AWS_ACCESS_KEY_ID \
+     --secret id=aws_secret_access_key,env=AWS_SECRET_ACCESS_KEY \
      -t "$IMAGE" -f blog/Dockerfile .
```

`GAPI` stays as a `--build-arg` — it's the public Google API client ID embedded into the JS bundle, not a secret.

## Why

BuildKit's linter has been firing on every CI build:

```
SecretsUsedInArgOrEnv: Do not use ARG or ENV instructions for sensitive data (ARG "AWS_ACCESS_KEY_ID") (line 24)
SecretsUsedInArgOrEnv: Do not use ARG or ENV instructions for sensitive data (ARG "AWS_SECRET_ACCESS_KEY") (line 25)
```

(The "2 warnings found" line at the end of every successful build.) `ARG`/`ENV` values get baked into the image layer history — anyone who can `docker pull` from the NAS push registry (or anyone on the LAN with `insecure-registries` set for `nas.home.arpa:5001`) can recover the values with `docker history --no-trunc <image>`. **Real exfiltration surface, not a theoretical lint.**

BuildKit secrets mount the value into a single RUN's environment and never write it to a layer.

## `required=true`

Set on both mounts so the build fails loud with a clear error if the CI secret is missing — vs. silently running `go test` with empty creds (DynamoDB returns AccessDenied → tests "fail" with confusing error messages, would burn time chasing the wrong cause).

## Validation (local, Docker Desktop arm64 native)

Replicated the workflow flags 1:1:

```
docker build \
  --build-arg GAPI="dummy-test-gapi" \
  --secret id=aws_access_key_id,env=AWS_ACCESS_KEY_ID \
  --secret id=aws_secret_access_key,env=AWS_SECRET_ACCESS_KEY \
  -t blog:buildkit-secrets-test -f blog/Dockerfile .
```

- Built successfully (`sha256:0cdf2fea0c95b3…`) → confirms `go test` ran successfully inside the build with the secret-mounted creds (it hits DynamoDB; if the secrets hadn't been wired right, the build would have failed at the test step).
- `docker history --no-trunc blog:buildkit-secrets-test` searched for `AWS_ACCESS_KEY_ID=`, `AWS_SECRET_ACCESS_KEY=`, the literal cred values, and `AKIA` prefix → **0 matches**. Layer history is clean.
- `yamllint` on the modified workflow: passes.

## After this merges

- `SecretsUsedInArgOrEnv` warnings disappear from the build logs.
- The blog image stored in `nas.home.arpa:5001/blog:develop` (and eventually `:latest`) no longer leaks AWS creds via `docker history`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
