### PR TITLE
fix(metrics): exclude /metrics from gin gzip middleware (double-gzip)

### DIFF
--- a/blog/app.go
+++ b/blog/app.go
@@ -147,7 +147,12 @@ func LoadMiddlewares(server *gin.Engine) {
 	server.Use(securityHeadersMiddleware())
 	server.Use(staticCacheMiddleware())
 	server.Use(unauthorizedMiddleware())
-	server.Use(gzip.Gzip(gzip.BestCompression))
+	// Exclude /metrics — promhttp.Handler() already compresses when the client
+	// sends Accept-Encoding: gzip (Prometheus does). Wrapping it here would
+	// gzip the response a second time, and Prometheus's single decompression
+	// pass would leave it staring at "\x1f" (inner gzip magic) and emit:
+	//   "expected a valid start token, got \"\\x1f\" (\"INVALID\")"
+	server.Use(gzip.Gzip(gzip.BestCompression, gzip.WithExcludedPaths([]string{"/metrics"})))
 
 }
 


### PR DESCRIPTION
## What

One-line fix: pass `gzip.WithExcludedPaths([]string{"/metrics"})` to the global `gin-contrib/gzip` middleware so it stops re-compressing the already-compressed Prometheus exposition response.

```diff
- server.Use(gzip.Gzip(gzip.BestCompression))
+ server.Use(gzip.Gzip(gzip.BestCompression, gzip.WithExcludedPaths([]string{"/metrics"})))
```

## Why

Discovered live: Prometheus target for the dev blog is `down` with parse error:

```
expected a valid start token, got "\x1f" ("INVALID") while parsing: "\x1f"
```

Reproduced with curl on the live container:

```
$ curl -H "Accept-Encoding: gzip" -H "Authorization: Bearer ..." \
       http://192.168.1.151:85/metrics | xxd | head -1
00000000: 1f8b 0800 0000 0000 00ff 1f8b 0800 0000  ................
```

**Two gzip headers stacked** — body is `gzip(gzip(metrics))`. Source of the double-compression:

1. `promhttp.Handler()` (the Go Prometheus client) auto-compresses when the client sends `Accept-Encoding: gzip` — Prometheus always does.
2. The global `gin-contrib/gzip` middleware then sees the same `Accept-Encoding: gzip` request and compresses the already-compressed response a second time.

Prometheus's single decompression pass strips one gzip layer, leaves the inner gzip stream, and tries to parse the `\x1f` magic byte as the text exposition format → fails.

Excluding `/metrics` from the gin middleware lets `promhttp` handle its own compression cleanly (which Prometheus expects).

## Validation

- Locally: `go build ./...` + `go vet ./...` clean. (Tests hit DynamoDB — CI runs them.)
- The reproduction was on the **live deployed container**, so we know what shape the bug has; once this rolls out, target moves `down → up` within one scrape interval (60s) and `blog_http_requests_total` starts showing in Grafana.

## Note on the broader miss

The original PR (#496) used `curl /metrics` without `Accept-Encoding: gzip` for validation, which dodged this branch of the middleware entirely. Going forward I'll exercise the auth + gzip path that real Prometheus traffic uses, not just the plain-text path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
