### PR TITLE
log: switch logrus to JSON formatter for Loki LogQL field extraction

### DIFF
--- a/blog/app.go
+++ b/blog/app.go
@@ -45,6 +45,16 @@ var (
 )
 
 func init() {
+	// Emit logs as JSON so Grafana Loki / LogQL can extract fields with
+	// `| json` instead of regex over freeform text. logrus's default
+	// TextFormatter renders `level=info msg="…"` which works but is
+	// strictly weaker downstream — JSON gives `level="info"`, `msg=…`,
+	// and any `log.WithField(...)`-attached fields as first-class labels.
+	// RFC3339Nano keeps sub-ms precision for request-rate analysis.
+	log.SetFormatter(&log.JSONFormatter{
+		TimestampFormat: time.RFC3339Nano,
+	})
+
 	prometheus.MustRegister(httpRequestsTotal, httpRequestDuration)
 }
 


### PR DESCRIPTION
## What

Switch logrus's default `TextFormatter` to `JSONFormatter` so log lines emitted by the blog parse cleanly with LogQL's `| json` parser now that the Studio has Loki + Alloy shipping every container's stdout.

```diff
 func init() {
+    log.SetFormatter(&log.JSONFormatter{
+        TimestampFormat: time.RFC3339Nano,
+    })
+
     prometheus.MustRegister(httpRequestsTotal, httpRequestDuration)
 }
```

## Why

Default rendering: `level=info msg="Server is starting..." server="..."`. Strictly weaker downstream — Loki has to regex over freeform text.

JSON rendering: `{"time":"…","level":"info","msg":"…","server":"…"}`. LogQL extracts every field as a first-class label in one parser pass:

```
{service="blog-in-golang-develop"} | json | level="error"
{service="blog-in-golang-develop"} | json | route="/article/:article_id"
```

RFC3339Nano keeps sub-millisecond precision so request-rate analysis isn't clamped to whole-second buckets.

Placed in `init()` before `prometheus.MustRegister` so every log line — including those at startup — is already structured.

## Pairs with

[#???] — Grafana blog dashboard, whose two Loki-side timeseries (`Log rate by level`, `Errors over time`) both call `| json` and depend on this PR to extract a usable `level` field. The dashboard's live-tail and Prometheus panels work without this; the level-aware ones light up once this lands.

## Validation

- `go build ./...` and `go vet ./...` clean locally.
- No runtime dependencies — `time` already imported, `log` is the standing `sirupsen/logrus` alias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
