### PR TITLE
monitoring: add Grafana blog dashboard (provisioned via Grafana API)

### DIFF
--- a/.github/workflows/studio-workflow.yml
+++ b/.github/workflows/studio-workflow.yml
@@ -229,3 +229,56 @@ jobs:
             command="curl --fail --header 'accept-encoding: gzip' "$line" > /dev/null"
             eval "$command"
           done < $TEST
+
+  # Provisions blog-owned Grafana dashboards (monitoring/dashboards/*.json) to
+  # the Studio's Grafana via its HTTP API on every develop push that touches
+  # one of those files. The JSON files in this repo are the source of truth;
+  # any UI edits in Grafana get overwritten on the next push.
+  #
+  # The dashboards reference blog-emitted metric/label names (blog_http_*),
+  # so ownership stays here rather than in studio-configs (which only owns
+  # the Grafana install itself + datasources + infra-wide dashboards).
+  #
+  # Auth: secrets.GRAFANA_TOKEN — Grafana Service Account API token (Editor).
+  # The runner reaches Grafana over the docker bridge via host.docker.internal,
+  # not through the Authentik-fronted public route (forwardauth doesn't pass
+  # bearer-only API calls).
+  provision-grafana:
+    if: github.ref == 'refs/heads/develop'
+    runs-on: [self-hosted, Linux, ARM64, studio]
+    env:
+      GRAFANA_URL: http://host.docker.internal:3000
+      GRAFANA_TOKEN: ${{ secrets.GRAFANA_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Get Changed Dashboards
+        id: changed-dashboards
+        uses: tj-actions/changed-files@v47
+        with:
+          files: monitoring/dashboards/*.json
+      - name: Provision dashboards via Grafana API
+        if: steps.changed-dashboards.outputs.any_changed == 'true'
+        shell: bash
+        run: |
+          set -eo pipefail
+          if [ -z "$GRAFANA_TOKEN" ]; then
+            echo "::warning::secrets.GRAFANA_TOKEN is unset — skipping provisioning"
+            exit 0
+          fi
+          for f in ${{ steps.changed-dashboards.outputs.all_changed_files }}; do
+            echo "uploading $f"
+            # `id: null` forces upsert by `uid`. POST /api/dashboards/db
+            # returns 200 with the canonical url + version on success.
+            jq -n --slurpfile dash "$f" --arg msg "ci ${{ github.sha }}" '{
+              dashboard: ($dash[0] | .id = null),
+              overwrite: true,
+              message: $msg
+            }' > /tmp/grafana-payload.json
+            response=$(curl -fsSL -X POST \
+              -H "Authorization: Bearer $GRAFANA_TOKEN" \
+              -H "Content-Type: application/json" \
+              --data @/tmp/grafana-payload.json \
+              "$GRAFANA_URL/api/dashboards/db")
+            echo "$response" | jq -r '"  ok: " + .url + "  v" + (.version|tostring)'
+          done

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,0 +1,36 @@
+# monitoring/
+
+Source of truth for blog-specific Grafana dashboards. Each `dashboards/*.json` is
+provisioned to the Studio's Grafana through its HTTP API by the `provision-grafana`
+job in `.github/workflows/studio-workflow.yml` on every `develop` push that
+touches a file here.
+
+The repo doesn't own Grafana itself (that's `studio-configs`) — only the
+dashboards that reference this repo's metric and log label names.
+
+## How a dashboard gets to Grafana
+
+1. Commit a JSON dashboard to `monitoring/dashboards/`. `uid` must be stable
+   (Grafana uses it for upsert).
+2. Push to `develop`. The CI job uploads it as the contents of a Grafana API
+   payload (`POST /api/dashboards/db`) using `secrets.GRAFANA_TOKEN`.
+3. The dashboard appears in Grafana within seconds.
+
+UI edits in Grafana will be overwritten on the next deploy — the JSON file is
+the source of truth. If you want to iterate on a panel visually, do it in
+Grafana, export the JSON (`Share → Export → Save JSON`), and commit it back.
+
+## Secret
+
+`GRAFANA_TOKEN` — Grafana Service Account token, role Editor (Admin if a
+dashboard ever needs to write Library Panels). Created in Grafana under
+*Administration → Service accounts → blog-in-golang-ci → Add token*.
+
+## Layout
+
+```
+monitoring/
+├── README.md
+└── dashboards/
+    └── blog.json     # uid blog-http-logs — HTTP metrics + Loki logs
+```

--- a/monitoring/dashboards/blog.json
+++ b/monitoring/dashboards/blog.json
@@ -1,0 +1,743 @@
+{
+  "uid": "blog-http-logs",
+  "title": "Blog \u2014 HTTP & Logs",
+  "tags": [
+    "blog",
+    "prometheus",
+    "loki"
+  ],
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "30s",
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "editable": true,
+  "graphTooltip": 1,
+  "panels": [
+    {
+      "type": "row",
+      "id": 1,
+      "title": "Overview",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "panels": []
+    },
+    {
+      "type": "stat",
+      "id": 2,
+      "title": "Req rate",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value_and_name",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "expr": "sum(rate(blog_http_requests_total[5m]))",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "id": 3,
+      "title": "4xx rate",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value_and_name",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "expr": "sum(rate(blog_http_requests_total{status=~\"4..\"}[5m]))",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "id": 4,
+      "title": "5xx rate",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value_and_name",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.01
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "expr": "sum(rate(blog_http_requests_total{status=~\"5..\"}[5m]))",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "id": 5,
+      "title": "p95 latency",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value_and_name",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.25
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le)(rate(blog_http_request_duration_seconds_bucket[5m])))",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "id": 6,
+      "title": "Traffic",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "id": 7,
+      "title": "Rate by status code (stacked)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "lineInterpolation": "smooth",
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "expr": "sum by (status)(rate(blog_http_requests_total[5m]))",
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 8,
+      "title": "Rate by route",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "lineInterpolation": "smooth",
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "expr": "sum by (route)(rate(blog_http_requests_total[5m]))",
+          "legendFormat": "{{route}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "id": 9,
+      "title": "Latency",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "id": 10,
+      "title": "Latency percentiles (overall)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 15
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "lineInterpolation": "smooth",
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le)(rate(blog_http_request_duration_seconds_bucket[5m])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "expr": "histogram_quantile(0.90, sum by (le)(rate(blog_http_request_duration_seconds_bucket[5m])))",
+          "legendFormat": "p90",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le)(rate(blog_http_request_duration_seconds_bucket[5m])))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 11,
+      "title": "p95 latency by route",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 15
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "lineInterpolation": "smooth",
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le,route)(rate(blog_http_request_duration_seconds_bucket[5m])))",
+          "legendFormat": "{{route}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "id": 12,
+      "title": "Logs",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "panels": []
+    },
+    {
+      "type": "logs",
+      "id": 13,
+      "title": "Live blog-dev logs (most-recent first)",
+      "datasource": {
+        "type": "loki",
+        "uid": "P982945308D3682D1"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "options": {
+        "showLabels": false,
+        "showCommonLabels": false,
+        "showTime": true,
+        "wrapLogMessage": true,
+        "prettifyLogMessage": true,
+        "enableLogDetails": true,
+        "sortOrder": "Descending",
+        "dedupStrategy": "none"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "P982945308D3682D1"
+          },
+          "expr": "{service=\"blog-in-golang-develop\"} | json",
+          "refId": "A",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 14,
+      "title": "Log rate by level",
+      "datasource": {
+        "type": "loki",
+        "uid": "P982945308D3682D1"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 34
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "logs",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "lineInterpolation": "smooth",
+            "showPoints": "never",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "P982945308D3682D1"
+          },
+          "expr": "sum by (level) (rate({service=\"blog-in-golang-develop\"} | json [5m]))",
+          "legendFormat": "{{level}}",
+          "refId": "A",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 15,
+      "title": "Errors over time",
+      "datasource": {
+        "type": "loki",
+        "uid": "P982945308D3682D1"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 34
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "lineInterpolation": "smooth",
+            "showPoints": "never",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "P982945308D3682D1"
+          },
+          "expr": "sum(count_over_time({service=\"blog-in-golang-develop\"} | json | level=\"error\" [1m]))",
+          "legendFormat": "errors",
+          "refId": "A",
+          "queryType": "range"
+        }
+      ]
+    }
+  ],
+  "templating": {
+    "list": []
+  },
+  "annotations": {
+    "list": []
+  }
+}


### PR DESCRIPTION
## What

First Grafana dashboard provisioned out of this repo, plus the CI machinery that uploads it.

```
monitoring/
├── README.md                                # how dashboards reach Grafana, required secret
└── dashboards/
    └── blog.json                            # uid blog-http-logs, 15 panels
.github/workflows/studio-workflow.yml        # new provision-grafana job
```

## Why this lives here, not studio-configs

The dashboard's panels reference *this repo's* metric names (`blog_http_requests_total`, `blog_http_request_duration_seconds`) and log label values (`service="blog-in-golang-develop"`). Coupled to blog code → ownership lives with the blog code. studio-configs only owns Grafana itself + the datasources + any infra-wide dashboards.

## Dashboard

Mirrors the existing `claw-jobs-*` convention — `schemaVersion: 38`, Prometheus + Loki datasources by their concrete UIDs, row headers between sections, gridded for 24-col layout:

| Row | Panels |
|---|---|
| **Overview** (h=4) | Req rate · 4xx rate (threshold orange) · 5xx rate (threshold red) · p95 latency (threshold orange/red) |
| **Traffic** (h=8) | Rate by status code (stacked) · Rate by route |
| **Latency** (h=8) | p50 / p90 / p99 overall · p95 by route |
| **Logs** (h=10 + h=6) | Live JSON-parsed tail (w=24) · Log rate by level · Errors over time |

The two Loki timeseries lean on the paired `log: switch logrus to JSON formatter` PR (#498) to extract a usable `level` field. Live tail + every Prometheus panel work without it.

## CI: provision-grafana job

New job in `studio-workflow.yml`:

- Triggers on `develop` push when any `monitoring/dashboards/*.json` changes
- Runs on the Studio self-hosted runner, reaches Grafana over the docker bridge at `http://host.docker.internal:3000` (not via Traefik — Authentik forwardauth doesn't pass bearer-only API calls)
- Auth: `secrets.GRAFANA_TOKEN` — Grafana Service Account API token, Editor role
- Payload shape: `{ dashboard: <json with id=null>, overwrite: true, message: "ci <sha>" }` — `id=null` forces upsert by `uid`
- Gracefully no-ops with `::warning::` if `GRAFANA_TOKEN` is unset

## Validation (live on the Studio)

I ran the exact API path the CI uses (admin basic-auth substituted for the SA bearer for the local test, identical semantics):

```
POST /api/dashboards/db
  status   = success
  url      = /d/blog-http-logs/blog-e28094-http-and-logs
  uid      = blog-http-logs
  version  = 1

/api/search?query=Blog
  → "Blog — HTTP & Logs"

prometheus panel query
  sum(rate(blog_http_requests_total[5m])) = 0.033 req/s
```

Also confirmed dropping the file-based provisioner from the Studio compose first (a remnant from an earlier wrong-architecture test) was necessary — Grafana refuses API writes over file-provisioned dashboards. Studio is back to its canonical state.

## Secret required (already configured per chat)

`GRAFANA_TOKEN` — Grafana Service Account token created under *Administration → Service accounts → blog-in-golang-ci*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
