### PR TITLE
log: route gin access logs through logrus (kills JSONParserErr in LogQL)

### DIFF
--- a/blog/app.go
+++ b/blog/app.go
@@ -65,7 +65,15 @@ func main() {
 
 	log.Info("Server is starting...")
 	gin.SetMode(gin.ReleaseMode)
-	httpServer := gin.Default()
+	// gin.New() instead of gin.Default() — Default() auto-registers Gin's
+	// own text-format access logger and writes lines like
+	//   [GIN] 2026/05/28 - 20:15:28 | 200 | 64.417µs | ::1 | GET "/healthz"
+	// which Loki's `| json` parser can't read, defeating the structured-log
+	// work in init(). Recovery() still gets us panic protection; the
+	// equivalent of Default()'s Logger() lives in accessLogMiddleware below
+	// and emits one JSON line per request via logrus.
+	httpServer := gin.New()
+	httpServer.Use(gin.Recovery())
 	httpServer.LoadHTMLGlob("templates/*")
 	// Middlewares MUST be registered before routes — Gin snapshots
 	// engine.Handlers into each route's frozen handler chain at registration
@@ -154,6 +162,7 @@ func LoadServerRoutes(server *gin.Engine) {
 func LoadMiddlewares(server *gin.Engine) {
 
 	server.Use(metricsMiddleware())
+	server.Use(accessLogMiddleware())
 	server.Use(securityHeadersMiddleware())
 	server.Use(staticCacheMiddleware())
 	server.Use(unauthorizedMiddleware())
@@ -164,6 +173,41 @@ func LoadMiddlewares(server *gin.Engine) {
 	//   "expected a valid start token, got \"\\x1f\" (\"INVALID\")"
 	server.Use(gzip.Gzip(gzip.BestCompression, gzip.WithExcludedPaths([]string{"/metrics"})))
 
+}
+
+// accessLogMiddleware emits one structured JSON line per request via
+// logrus, replacing Gin's text-format access logger. Fields stay bounded
+// (route TEMPLATE not raw path; numeric status; integer-µs latency), so
+// Loki streams don't blow up on cardinality. Level escalates to Warn at
+// 4xx and Error at 5xx so `{service="..."} | json | level="error"` in
+// LogQL surfaces actual failures rather than every healthcheck ping.
+func accessLogMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		start := time.Now()
+		c.Next()
+		route := c.FullPath() // route TEMPLATE — same source as metrics labels
+		if route == "" {
+			route = "unmatched"
+		}
+		status := c.Writer.Status()
+		latencyMicros := time.Since(start).Microseconds()
+		entry := log.WithFields(log.Fields{
+			"client_ip":  c.ClientIP(),
+			"method":     c.Request.Method,
+			"path":       c.Request.URL.Path,
+			"route":      route,
+			"status":     status,
+			"latency_us": latencyMicros,
+		})
+		switch {
+		case status >= 500:
+			entry.Error("request")
+		case status >= 400:
+			entry.Warn("request")
+		default:
+			entry.Info("request")
+		}
+	}
 }
 
 // metricsMiddleware records request count + duration into the Prometheus


### PR DESCRIPTION
## What

Replaces Gin's default text-format access logger with one that routes through logrus, so every line emitted by the blog container — app logs *and* per-request access logs — parses cleanly with LogQL's `| json` in the dashboard panels.

```diff
- httpServer := gin.Default()
+ httpServer := gin.New()
+ httpServer.Use(gin.Recovery())
  ...
  server.Use(metricsMiddleware())
+ server.Use(accessLogMiddleware())
  server.Use(securityHeadersMiddleware())
```

## Why

[#498](https://github.com/etzelm/blog-in-golang/pull/498) and [#499](https://github.com/etzelm/blog-in-golang/pull/499) turned on JSON-formatted logrus output and added the Grafana dashboard expecting `| json`-parseable lines. But `gin.Default()` registers Gin's *own* text-format access logger, which writes lines like:

```
[GIN] 2026/05/28 - 20:15:28 | 200 | 64.417µs | ::1 | GET "/healthz"
```

Healthchecks fire every 30s, Prometheus scrapes every 60s, plus normal traffic — those Gin lines vastly outnumber logrus-emitted lines, and the dashboard's Loki panels were chocking on them:

> `__error__ = JSONParserErr`
> `__error_details__ = Value looks like object, but can't find closing '}' symbol`

(Visible in PR #499's live tail panel.) `Log rate by level` stayed flat, `Errors over time` never ticked.

## The new middleware

```go
func accessLogMiddleware() gin.HandlerFunc {
    return func(c *gin.Context) {
        start := time.Now()
        c.Next()
        route := c.FullPath() // route TEMPLATE — same source as metrics labels
        if route == "" {
            route = "unmatched"
        }
        status := c.Writer.Status()
        latencyMicros := time.Since(start).Microseconds()
        entry := log.WithFields(log.Fields{
            "client_ip":  c.ClientIP(),
            "method":     c.Request.Method,
            "path":       c.Request.URL.Path,
            "route":      route,
            "status":     status,
            "latency_us": latencyMicros,
        })
        switch {
        case status >= 500: entry.Error("request")
        case status >= 400: entry.Warn("request")
        default:            entry.Info("request")
        }
    }
}
```

**Bounded labels** so LogQL stream cardinality stays sane: `route` is the route TEMPLATE (`/article/:article_id`) same as the metrics middleware uses, not the raw path. Numeric `status`, integer-µs `latency_us`. **Level-tiered** so `| level="error"` in LogQL surfaces real failures rather than every healthcheck.

**Order matters**: registered AFTER `metricsMiddleware` so the Prometheus metrics middleware still observes total end-to-end (it's the outermost middleware). Access log observes everything except metrics overhead. The existing comment in `LoadMiddlewares` already documents this ordering.

## Sample line, after deploy

```json
{
  "client_ip": "::1",
  "latency_us": 64,
  "level": "info",
  "method": "GET",
  "msg": "request",
  "path": "/healthz",
  "route": "/healthz",
  "status": 200,
  "time": "2026-05-28T20:15:28.389123456Z"
}
```

LogQL queries like these will start working:

```logql
{service="blog-in-golang-develop"} | json | status >= 400
{service="blog-in-golang-develop"} | json | route="/article/:article_id" | latency_us > 100000
sum by (status) (rate({service="blog-in-golang-develop"} | json [5m]))
```

## Validation

- `go build ./...` and `go vet ./...` clean locally.
- No new imports — `time` and `log` (the logrus alias) already in `app.go`.
- Diff: `blog/app.go +45 / -1`.

## After deploy

The two log-side panels on the dashboard light up:

| Panel | Before | After |
|---|---|---|
| Live tail | `__error__ = JSONParserErr` on every line | clean JSON-parsed lines |
| Log rate by level | (no data, all `__error__`) | `info` series for healthchecks + normal traffic; `warn`/`error` if/when 4xx/5xx happen |
| Errors over time | (no data) | counts of `level="error"` lines (5xx responses) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
