### PR TITLE
dashboard: skip JSONParserErr in Loki aggregations

### DIFF
--- a/monitoring/dashboards/blog.json
+++ b/monitoring/dashboards/blog.json
@@ -667,7 +667,7 @@
             "type": "loki",
             "uid": "P982945308D3682D1"
           },
-          "expr": "sum by (level) (rate({service=\"$log_service\"} | json [5m]))",
+          "expr": "sum by (level) (rate({service=\"$log_service\"} | json | __error__=\"\" [5m]))",
           "legendFormat": "{{level}}",
           "refId": "A",
           "queryType": "range"
@@ -726,7 +726,7 @@
             "type": "loki",
             "uid": "P982945308D3682D1"
           },
-          "expr": "sum(count_over_time({service=\"$log_service\"} | json | level=\"error\" [1m]))",
+          "expr": "sum(count_over_time({service=\"$log_service\"} | json | __error__=\"\" | level=\"error\" [1m]))",
           "legendFormat": "errors",
           "refId": "A",
           "queryType": "range"


### PR DESCRIPTION
## What

Two-line dashboard JSON patch — append `| __error__=""` after `| json` on the two Loki aggregation queries.

```diff
  panel "Log rate by level":
- sum by (level) (rate({service="$log_service"} | json [5m]))
+ sum by (level) (rate({service="$log_service"} | json | __error__="" [5m]))

  panel "Errors over time":
- sum(count_over_time({service="$log_service"} | json | level="error" [1m]))
+ sum(count_over_time({service="$log_service"} | json | __error__="" | level="error" [1m]))
```

Plus a trailing newline at EOF.

## Why

Caught live after #500 deployed at `20:28:04`:

```
HTTP 400
pipeline error: 'JSONParserErr' for series:
'{__error__="JSONParserErr",
  __error_details__="Value looks like object, but can't find
                     closing '}' symbol", service="...", ...}'.
Use a label filter to intentionally skip this error.
(e.g | __error__!="JSONParserErr").
```

`#500` made every *new* line emit JSON, but Loki's 30-day retention still holds **pre-#500 Gin-text-format lines** that came in before the redeploy. `rate({...} | json [5m])` over a window that spans both formats trips `JSONParserErr` at the metric layer, and Loki returns the whole query as **400** instead of dropping the unparseable lines.

`Errors over time` happened to dodge it because its `level="error"` filter ran *after* `| json` and incidentally hid the error rows — same defensive fix applies for safety.

The live-tail panel (panel 13) is deliberately **not** patched. Keeping the parse-error chip visible on individual lines is useful for catching future regressions — only the metric aggregations need the filter.

## Validation

Uploaded as v4 via the same Grafana API path the CI uses:

| Check | Result |
|---|---|
| `POST /api/dashboards/db` | `status=success v=4` |
| Panel 14 query re-run | `HTTP 200` · `streams=1` · `level=info` · `last_val=0.05 lines/s` · `n_points=42` (healthcheck rate) |
| Panel 15 query re-run | `HTTP 200` · `streams=0` (no 5xx logged yet — correct) |

When this merges the `provision-grafana` job re-uploads v5 over the live v4 — idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
