### PR TITLE
log: lokirus hook for GCP — direct logrus -> Loki via public push endpoint

### DIFF
--- a/blog/app.go
+++ b/blog/app.go
@@ -18,6 +18,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
+	"github.com/yukitsune/lokirus"
 )
 
 // Prometheus metrics. Labels:
@@ -55,6 +56,36 @@ func init() {
 		TimestampFormat: time.RFC3339Nano,
 	})
 
+	// Loki push hook for GCP. The Studio containers (dev + prod) are tailed
+	// by Grafana Alloy on the host, which reads the docker journal and ships
+	// to Loki over the compose network — no in-process hook needed. The GCP
+	// box has a 0.5 vCPU budget that doesn't justify a separate shipper
+	// process, so the blog binary pushes its own logs directly via lokirus.
+	//
+	// When LOKI_URL is set, the hook batches logrus entries (Info+) and
+	// POSTs them to the configured Loki endpoint using basic auth. Static
+	// labels (service / env / source) determine the Loki stream identity —
+	// pinned to the GCP container's slot so it never collides with the
+	// Alloy-shipped studio streams.
+	if lokiURL := os.Getenv("LOKI_URL"); lokiURL != "" {
+		opts := lokirus.NewLokiHookOptions().
+			WithBasicAuth(os.Getenv("LOKI_USERNAME"), os.Getenv("LOKI_PASSWORD")).
+			WithFormatter(&log.JSONFormatter{
+				TimestampFormat: time.RFC3339Nano,
+			}).
+			WithStaticLabels(lokirus.Labels{
+				"service": "blog-in-golang-gcp",
+				"env":     "gcp",
+				"source":  "lokirus",
+			})
+		hook := lokirus.NewLokiHookWithOpts(
+			lokiURL,
+			opts,
+			log.InfoLevel, log.WarnLevel, log.ErrorLevel, log.FatalLevel, log.PanicLevel,
+		)
+		log.AddHook(hook)
+	}
+
 	prometheus.MustRegister(httpRequestsTotal, httpRequestDuration)
 }
 
@@ -87,7 +118,11 @@ func main() {
 	LoadMiddlewares(httpServer)
 	LoadStaticFileRoutes(httpServer)
 	LoadServerRoutes(httpServer)
-	log.WithField("server", httpServer).Info("Default Gin server created.")
+	// Don't log the *gin.Engine as a structured field — it embeds
+	// `gin.HandlerFunc` slices that json.Marshal can't serialize, so
+	// JSONFormatter / lokirus drop the line with
+	//   "failed to marshal fields to JSON, json: unsupported type: gin.HandlerFunc".
+	log.Info("Gin server created.")
 
 	go func() {
 		for range time.Tick(time.Hour * 3) {

--- a/blog/go.mod
+++ b/blog/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/sirupsen/logrus v1.9.4
 	github.com/stretchr/testify v1.11.1
+	github.com/yukitsune/lokirus v1.0.1
 	golang.org/x/crypto v0.52.0
 )
 

--- a/blog/go.sum
+++ b/blog/go.sum
@@ -242,6 +242,8 @@ github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.3.1 h1:waO7eEiFDwidsBN6agj1vJQ4AG7lh2yqXyOXqhgQuyY=
 github.com/ugorji/go/codec v1.3.1/go.mod h1:pRBVtBSKl77K30Bv8R2P+cLSGaTtex6fsA2Wjqmfxj4=
+github.com/yukitsune/lokirus v1.0.1 h1:w8BbIJVBFoaF6M6XimwJLDc7sw3wsFbQp3OxdQZCNq8=
+github.com/yukitsune/lokirus v1.0.1/go.mod h1:rcw/P3XPHGSMf20+/deZ2m3z0gU0L77fIt7Wd3GlvhQ=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/zeebo/assert v1.1.0 h1:hU1L1vLTHsnO8x8c9KAR5GmM5QscxHg5RNU5z5qbUWY=

--- a/monitoring/dashboards/blog.json
+++ b/monitoring/dashboards/blog.json
@@ -765,7 +765,7 @@
       {
         "name": "log_service",
         "type": "custom",
-        "query": "dev : blog-in-golang-develop, prod : blog-in-golang-latest",
+        "query": "dev : blog-in-golang-develop, prod : blog-in-golang-latest, gcp : blog-in-golang-gcp",
         "options": [
           {
             "text": "blog-in-golang-develop",
@@ -775,6 +775,11 @@
           {
             "text": "blog-in-golang-latest",
             "value": "blog-in-golang-latest",
+            "selected": false
+          },
+          {
+            "text": "blog-in-golang-gcp",
+            "value": "blog-in-golang-gcp",
             "selected": false
           }
         ],


### PR DESCRIPTION
## What

Direct `logrus → Loki` push hook in the blog binary, scoped to the GCP container so the half-vCPU box doesn't need a separate shipper process. Studio dev + prod stay Alloy-shipped; GCP becomes self-shipping.

Triggered by the presence of `LOKI_URL` in the container env — empty/unset means the hook isn't attached. The GCP container is the only instance that gets the three `LOKI_*` env vars threaded through, so this is effectively a "GCP-only" code path even though it's a single binary.

## Labels

Static only — no dynamic provider, so cardinality stays bounded regardless of request volume. lokirus's default `defaultDynamicLabelProvider` already returns empty, so nothing from `log.WithField(...)` leaks into stream identity.

```
service = blog-in-golang-gcp     # so it never collides with the alloy-shipped streams
env     = gcp
source  = lokirus
level   = info | warning | error | fatal | panic    # added by lokirus's applyLevelLabel
```

(`detected_level`, `service_name`, etc. that show up in queries are Loki-derived helpers — not pushed.)

## Bundled cleanup

`app.go` used to log `log.WithField("server", httpServer)` to emit "Default Gin server created." with the engine object attached. The `*gin.Engine` embeds `gin.HandlerFunc` slices that `json.Marshal` can't serialize. The JSONFormatter (#498) was silently dropping that line on stdout; lokirus surfaced the failure as:

```
Failed to fire hook: failed to marshal fields to JSON,
json: unsupported type: gin.HandlerFunc
```

Stripped the structured field — the message alone is enough.

## Dashboard

`monitoring/dashboards/blog.json` — `log_service` helper gains a third option (`blog-in-golang-gcp`). When you flip `env` to gcp in the dropdown, the live tail / log-rate / errors panels follow.

## Validation — live, before push

Built locally, ran with the real `LOKI_URL` / `LOKI_USERNAME` / `LOKI_PASSWORD` (basicAuth set in [nas-configs !87](https://gitlab.traefik.mitchelletzel.com/etzelm/nas-configs/-/merge_requests/87)). Pinged `/healthz` and `/no-such-page`. Then queried Loki directly on the Studio:

```
GET .../query_range  {service="blog-in-golang-gcp"}
  -> 2 real streams (level=info, level=warning), 4 lines

GET .../query_range  {service="blog-in-golang-gcp"} | json
  -> client_ip, method, path, route, status, latency_us, msg, level
     ALL extracted cleanly, no JSONParserErr
```

No marshal-failure noise on stderr after the gin-engine fix.

## GCP env vars required (already set per chat)

```
LOKI_URL       = https://loki.traefik.mitchelletzel.com
LOKI_USERNAME  = blog-gcp
LOKI_PASSWORD  = (basicAuth password from !87, in 1Password)
```

`blog-in-golang` repo secrets are configured. They'll get threaded into the `gcp.master.yml` compose env when the Phase 2b deploy PR lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
