### PR TITLE
ci(gcp): force-rm container name before compose up (cross-project conflict)

### DIFF
--- a/.github/workflows/studio-workflow.yml
+++ b/.github/workflows/studio-workflow.yml
@@ -347,6 +347,17 @@ jobs:
             $GCP_BIN/docker load -i blog.tar
             $GCP_BIN/docker tag $IMAGE_AMD blog:latest
             rm -f blog.tar
+            # The container_name 'blog-in-golang' (set in gcp.master.yml) is
+            # a global identifier in Docker — it can collide across compose
+            # projects. The pre-Phase-2b container was created under a
+            # different project name (default = compose-dir basename); our
+            # new project 'blog-master' can't reuse the name without first
+            # removing the old container. --force-recreate only handles
+            # collisions WITHIN a project, so this rm is needed for the
+            # first Phase-2b master deploy. Subsequent deploys also benefit
+            # — anything that ever drifted into a 'wrong' project gets
+            # cleaned up automatically.
+            $GCP_BIN/docker rm -f blog-in-golang 2>/dev/null || true
             export AWS_ACCESS_KEY_ID='$AWS_ACCESS_KEY_ID'
             export AWS_SECRET_ACCESS_KEY='$AWS_SECRET_ACCESS_KEY'
             export METRICS_TOKEN='$METRICS_TOKEN'


### PR DESCRIPTION
## What

One-line fix to the `Deploy (master -> GCP)` SSH script — force-remove the container named `blog-in-golang` on GCP before `docker compose up`.

```diff
   $GCP_BIN/docker load -i blog.tar
   $GCP_BIN/docker tag $IMAGE_AMD blog:latest
   rm -f blog.tar
+  $GCP_BIN/docker rm -f blog-in-golang 2>/dev/null || true
   export AWS_ACCESS_KEY_ID='$AWS_ACCESS_KEY_ID'
   ...
   $GCP_BIN/docker compose -p blog-master -f docker-compose.yml up -d --force-recreate
```

## Why

The first Phase 2b master deploy ([run #26605511626](https://github.com/etzelm/blog-in-golang/actions/runs/26605511626/job/78399960084)) failed at the GCP step with:

```
Container blog-in-golang  Error response from daemon: Conflict.
The container name "/blog-in-golang" is already in use by container
"f6ee5fa2d1a716afc8150fa1f08d4193146a0fdf100ccffe3252d220c3e6e7eb".
```

`gcp.master.yml` pins `container_name: blog-in-golang`, which is a **global** identifier in the Docker daemon — names can collide across compose projects. The container already running on GCP was created by a previous workflow run (pre-Phase 2b) under a different project name (default = compose-dir basename, probably `blog-in-golang`). Our new project name is `blog-master`. `--force-recreate` only resolves collisions **within** the same project, so it didn't help.

## Why only GCP

Studio prod (the other deploy target in the same workflow) is brand new in Phase 2b — there's no prior container with that name on the Studio. Confirmed it came up on `:84` from the same failed run; `/healthz` returns `200`, `/metrics` with the bearer token returns `200`. Only the GCP leg failed.

## Defensive note

The `2>/dev/null || true` makes this idempotent — if no container exists, the rm is a silent no-op. Subsequent deploys benefit too: anything that ever drifts into a "wrong" project gets cleaned up automatically.

## After this merges

The next master push (or a manual re-run of the failed job's parent) gets through the GCP deploy step cleanly. CloudFront invalidation + the `public-urls.txt` smoke test (both currently `skipped` because they're gated on the GCP step's outcome) light up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
