### PR TITLE
ci: workflow_dispatch force_deploy input to bypass changed-files gate

### DIFF
--- a/.github/workflows/studio-workflow.yml
+++ b/.github/workflows/studio-workflow.yml
@@ -10,6 +10,20 @@ on:
       - 'master'
   pull_request:
   workflow_dispatch:
+    inputs:
+      # When triggered manually from the Actions UI, this lets you force the
+      # build + deploy paths to run even though `tj-actions/changed-files`
+      # would skip them (e.g. a workflow-only PR landed on master and now
+      # you want to redeploy prod — no app code changed, so the normal
+      # changed-files gate says "nothing to do"). Default true because the
+      # manual UI button is almost always pressed BECAUSE you want a deploy;
+      # set to false if you want to exercise the workflow without touching
+      # the live containers.
+      force_deploy:
+        description: 'Force build + deploy regardless of changed-files'
+        type: boolean
+        required: false
+        default: true
 
 jobs:
 
@@ -129,7 +143,7 @@ jobs:
             realtor/public/**
             realtor/src/**
       - name: Build & Push (develop, arm64)
-        if: github.ref == 'refs/heads/develop' && steps.changed-build-files.outputs.any_changed == 'true'
+        if: github.ref == 'refs/heads/develop' && (steps.changed-build-files.outputs.any_changed == 'true' || github.event.inputs.force_deploy == 'true')
         shell: bash
         run: |
           set -e
@@ -162,7 +176,7 @@ jobs:
           docker push "$IMAGE"
           docker system prune -f
       - name: Build & Push (master, arm64 for Studio prod + amd64 buildx for GCP tarball)
-        if: github.ref == 'refs/heads/master' && steps.changed-build-files.outputs.any_changed == 'true'
+        if: github.ref == 'refs/heads/master' && (steps.changed-build-files.outputs.any_changed == 'true' || github.event.inputs.force_deploy == 'true')
         shell: bash
         run: |
           set -e
@@ -270,7 +284,7 @@ jobs:
           popd
       - name: Deploy (develop -> Studio dev)
         id: deploy
-        if: github.ref == 'refs/heads/develop' && needs.build-push.outputs.build_changed == 'true'
+        if: github.ref == 'refs/heads/develop' && (needs.build-push.outputs.build_changed == 'true' || github.event.inputs.force_deploy == 'true')
         shell: bash
         run: |
           set -e
@@ -283,7 +297,7 @@ jobs:
           docker system prune -f
       - name: Deploy (master -> Studio prod)
         id: deploy-master-studio
-        if: github.ref == 'refs/heads/master' && needs.build-push.outputs.build_changed == 'true'
+        if: github.ref == 'refs/heads/master' && (needs.build-push.outputs.build_changed == 'true' || github.event.inputs.force_deploy == 'true')
         shell: bash
         env:
           REGISTRY: nas.home.arpa:5001
@@ -298,7 +312,7 @@ jobs:
           docker system prune -f
       - name: Deploy (master -> GCP)
         id: deploy-master-gcp
-        if: github.ref == 'refs/heads/master' && needs.build-push.outputs.build_changed == 'true'
+        if: github.ref == 'refs/heads/master' && (needs.build-push.outputs.build_changed == 'true' || github.event.inputs.force_deploy == 'true')
         shell: bash
         env:
           # GCP SSH target (private). Same secrets the old NAS-deploy used,


### PR DESCRIPTION
## What

Adds a `workflow_dispatch.inputs.force_deploy` boolean (default `true`) and OR's it into the existing `changed-files` gates on the four conditional build/deploy steps. Normal `push` events are unaffected — `github.event.inputs` is empty for `push`, so the new clause evaluates `false` and the existing changed-files gating applies as before.

```diff
   workflow_dispatch:
+    inputs:
+      force_deploy:
+        description: 'Force build + deploy regardless of changed-files'
+        type: boolean
+        required: false
+        default: true

   - name: Build & Push (develop, arm64)
-    if: github.ref == 'refs/heads/develop' && steps.changed-build-files.outputs.any_changed == 'true'
+    if: github.ref == 'refs/heads/develop' && (steps.changed-build-files.outputs.any_changed == 'true' || github.event.inputs.force_deploy == 'true')

   - name: Build & Push (master, ...)
   - name: Deploy (develop -> Studio dev)
   - name: Deploy (master -> Studio prod)
   - name: Deploy (master -> GCP)
   # all same pattern
```

## Why

[#503](https://github.com/etzelm/blog-in-golang/pull/503) wired up the master deploy paths; [#504](https://github.com/etzelm/blog-in-golang/pull/504) fixed the cross-project container name conflict on GCP that the first master run tripped on. But now we're stuck: any subsequent master sync only touches workflow YAML, not the changed-files glob (`blog/`, `realtor/`, etc.), so `build_changed=false` → every deploy step skips → GCP keeps serving the **pre-Phase-2b container** (404 on `/healthz`, 404 on `/metrics`, 502 on `/auth` after CloudFront invalidation peeled back the cache).

Confirmed live just now:
```
GCP  /healthz   -> HTTP 404   (endpoint added in #496, so this is pre-Phase-2b code)
GCP  /metrics   -> HTTP 404   (same)
GCP  /auth      -> HTTP 502   (origin error — old container degraded)
```

Studio prod is fine — it came up cleanly from the first run's earlier step (HTTP 200 across the board). It's only GCP that needs a fresh push, and we have no way to trigger that today without a no-op build-files commit.

## Use after merge

1. Merge this PR → `develop` → sync `develop` → `master`.
2. Actions tab → "blog-in-golang-studio" → **Run workflow** → pick `master`, leave `force_deploy` checked → Run.
3. With `build_changed=false` but `force_deploy='true'`, the master build runs both arm64 + buildx amd64, deploys Studio prod (idempotent re-up), deploys GCP with the #504 `docker rm -f blog-in-golang` pre-clean, invalidates CloudFront, smoke-tests via `public-urls.txt`.
4. `GCP /healthz` flips from 404 → 200; Phase 2b is live across both prod boxes.

After that one manual trigger, subsequent master pushes go back to the normal changed-files gating — `force_deploy` is *only* surfaced via `workflow_dispatch`, never on a push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
