### PR TITLE
Fix Loki panels to support all environments

### DIFF
--- a/monitoring/dashboards/blog.json
+++ b/monitoring/dashboards/blog.json
@@ -582,7 +582,7 @@
     {
       "type": "logs",
       "id": 13,
-      "title": "Live blog-dev logs (most-recent first)",
+      "title": "Live logs",
       "datasource": {
         "type": "loki",
         "uid": "P982945308D3682D1"
@@ -768,31 +768,31 @@
         "query": "dev : blog-in-golang-develop, prod : blog-in-golang-latest, gcp : blog-in-golang-gcp",
         "options": [
           {
-            "text": "blog-in-golang-develop",
+            "text": "dev",
             "value": "blog-in-golang-develop",
             "selected": true
           },
           {
-            "text": "blog-in-golang-latest",
+            "text": "prod",
             "value": "blog-in-golang-latest",
             "selected": false
           },
           {
-            "text": "blog-in-golang-gcp",
+            "text": "gcp",
             "value": "blog-in-golang-gcp",
             "selected": false
           }
         ],
         "current": {
           "selected": true,
-          "text": "blog-in-golang-develop",
+          "text": "dev",
           "value": "blog-in-golang-develop"
         },
         "multi": false,
         "includeAll": false,
-        "hide": 2,
-        "skipUrlSync": true,
-        "label": "log_service"
+        "hide": 0,
+        "skipUrlSync": false,
+        "label": "env (logs)"
       }
     ]
   },


### PR DESCRIPTION
## Summary
- The `log_service` dashboard variable was hidden (`hide: 2`) and defaulted to `blog-in-golang-develop`, so switching the `env` dropdown only affected Prometheus panels — Loki panels (log viewer, log rate, errors over time) were stuck showing dev logs regardless of selection.
- Un-hides `log_service` as a second dropdown labeled **env (logs)** with options dev / prod / gcp, matching the existing env dropdown.
- Fixes the option text labels to show "dev" / "prod" / "gcp" instead of the raw service names.
- Removes hardcoded "blog-dev" from the log panel title.

## Note
Grafana custom variables can't chain off each other, so this requires switching both dropdowns. A future improvement could add `env` labels to the Alloy-shipped Loki streams (dev/prod), which would let us replace `log_service` with a single `{env="$env"}` Loki selector — matching how GCP's lokirus hook already works.

## Test plan
- [ ] After CI provisions the dashboard, open it in Grafana
- [ ] Verify the new "env (logs)" dropdown appears next to the existing "env" dropdown
- [ ] Switch env (logs) to prod → Loki panels should show `blog-in-golang-latest` logs
- [ ] Switch env (logs) to gcp → Loki panels should show `blog-in-golang-gcp` logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)