### PR TITLE
fix(csp): allow Google Identity Services for OAuth login button

### DIFF
--- a/blog/app.go
+++ b/blog/app.go
@@ -332,11 +332,12 @@ func securityHeadersMiddleware() gin.HandlerFunc {
 
 		// Content Security Policy (relaxed for external resources)
 		csp := "default-src 'self'; " +
-			"script-src 'self' 'unsafe-inline' https://files.mitchelletzel.com; " +
-			"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
+			"script-src 'self' 'unsafe-inline' https://files.mitchelletzel.com https://accounts.google.com; " +
+			"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://accounts.google.com; " +
 			"img-src 'self' data: https: blob:; " +
 			"font-src 'self' https://fonts.gstatic.com; " +
-			"connect-src 'self' https://files.mitchelletzel.com; " +
+			"connect-src 'self' https://files.mitchelletzel.com https://accounts.google.com; " +
+			"frame-src https://accounts.google.com; " +
 			"frame-ancestors 'none';"
 		c.Header("Content-Security-Policy", csp)
 


### PR DESCRIPTION
## Summary
- The Content Security Policy blocked `accounts.google.com` from `script-src`, `style-src`, `connect-src`, and `frame-src`, preventing the Google Sign-In button from rendering in the realtor navbar
- Added `https://accounts.google.com` to the relevant CSP directives

## Test plan
- [ ] Merge and deploy to develop
- [ ] Verify the Google Sign-In button appears in the navbar at `/realtor`
- [ ] Verify sign-in flow works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)