### PR TITLE
fix(ci): wire force_deploy into provision-grafana

### DIFF
--- a/.github/workflows/studio-workflow.yml
+++ b/.github/workflows/studio-workflow.yml
@@ -454,7 +454,7 @@ jobs:
         with:
           files: monitoring/dashboards/*.json
       - name: Ensure Grafana folder exists
-        if: steps.changed-dashboards.outputs.any_changed == 'true'
+        if: steps.changed-dashboards.outputs.any_changed == 'true' || github.event.inputs.force_deploy == 'true'
         id: grafana-folder
         shell: bash
         run: |
@@ -479,7 +479,7 @@ jobs:
             echo "folder_uid=$uid" >> "$GITHUB_OUTPUT"
           fi
       - name: Provision dashboards via Grafana API
-        if: steps.changed-dashboards.outputs.any_changed == 'true'
+        if: steps.changed-dashboards.outputs.any_changed == 'true' || github.event.inputs.force_deploy == 'true'
         shell: bash
         run: |
           set -eo pipefail
@@ -488,7 +488,13 @@ jobs:
             exit 0
           fi
           FOLDER_UID="${{ steps.grafana-folder.outputs.folder_uid }}"
-          for f in ${{ steps.changed-dashboards.outputs.all_changed_files }}; do
+          CHANGED="${{ steps.changed-dashboards.outputs.all_changed_files }}"
+          if [ -n "$CHANGED" ]; then
+            FILES="$CHANGED"
+          else
+            FILES=$(ls monitoring/dashboards/*.json)
+          fi
+          for f in $FILES; do
             echo "uploading $f → folder $FOLDER_UID"
             jq -n --slurpfile dash "$f" --arg msg "ci ${{ github.sha }}" --arg fuid "$FOLDER_UID" '{
               dashboard: ($dash[0] | .id = null),

--- a/monitoring/dashboards/blog.json
+++ b/monitoring/dashboards/blog.json
@@ -6,7 +6,7 @@
     "prometheus",
     "loki"
   ],
-  "schemaVersion": 38,
+  "schemaVersion": 39,
   "version": 1,
   "refresh": "30s",
   "time": {


### PR DESCRIPTION
## Summary
- Adds `force_deploy` support to the `provision-grafana` job so `workflow_dispatch` can trigger provisioning even when no dashboard files changed
- When force-deploying, falls back to globbing all `monitoring/dashboards/*.json` since the changed-files list is empty
- Bumps `blog.json` schemaVersion 38→39 to trigger the changed-files gate on this merge, re-provisioning the dashboard into the new folder from #516

## Test plan
- [ ] Merge to develop — verify `provision-grafana` runs and uploads `blog.json` into the `blog-in-golang` folder
- [ ] Confirm the dashboard appears under the correct folder in the Grafana UI
- [ ] After merge, trigger a manual `workflow_dispatch` with `force_deploy=true` — verify provision steps run

🤖 Generated with [Claude Code](https://claude.com/claude-code)